### PR TITLE
Use the v7 prerelease of AXElements for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,5 +39,5 @@ end
 group :production do
   gem 'chef', '>= 11'
   gem 'berkshelf', '>= 3'
-  gem 'AXElements', '>= 6'
+  gem 'AXElements', '~> 7.0.0.pre'
 end

--- a/libraries/provider_mac_app_store.rb
+++ b/libraries/provider_mac_app_store.rb
@@ -31,7 +31,7 @@ class Chef
     class MacAppStore < Provider::LWRPBase
       include MacAppStoreCookbook::Helpers
 
-      AXE_VERSION ||= '~> 6.0'
+      AXE_VERSION ||= '~> 7.0.0.pre'
 
       use_inline_resources
 

--- a/spec/libraries/provider_mac_app_store_spec.rb
+++ b/spec/libraries/provider_mac_app_store_spec.rb
@@ -29,8 +29,8 @@ describe Chef::Provider::MacAppStore do
   end
 
   describe 'AXE_VERSION' do
-    it 'pins AXE to 6.x' do
-      expect(described_class::AXE_VERSION).to eq('~> 6.0')
+    it 'pins AXE to 7 prerelease' do
+      expect(described_class::AXE_VERSION).to eq('~> 7.0.0.pre')
     end
   end
 
@@ -288,7 +288,7 @@ describe Chef::Provider::MacAppStore do
       p = provider
       allow(p).to receive(:install_axe_gem).and_call_original
       expect(p).to receive(:compile_time).with(true)
-      expect(p).to receive(:version).with('~> 6.0')
+      expect(p).to receive(:version).with('~> 7.0.0.pre')
       expect(p).to receive(:action).with(:install)
       p.send(:install_axe_gem)
     end


### PR DESCRIPTION
The newer version of the mouse gem that it depends on seems to take care
of this silliness that was happening in Yosemite + Chef Omnibus:

```
mouser.c:73:11: error: using integer absolute value function 'abs' when
argument is of floating point type [-Werror,-Wabsolute-value]
while (!CLOSE_ENOUGH(current_point, end_point)) {
mouser.c:22:55: note: expanded from macro 'CLOSE_ENOUGH'
define CLOSE_ENOUGH(a,b) ((abs(a.x - b.x) < 1.0) && (abs(a.y - b.y) < 1.0))
mouser.c:73:11: note: use function 'fabs' instead
```

Looks like it was [fixed](https://github.com/AXElements/mouse/commit/1982ac5df2a1a3d56b1b72944122571537bd8376) in mouse 4.0.0.