### PR TITLE
Fix issue with bundled apps not getting accessibility rights

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,5 +22,5 @@ suites:
         password: <%= ENV['APPLE_ID_PASSWORD'] %>
         apps:
           - Microsoft Remote Desktop
-          - name: White Noise Lite
+          - name: White Noise Free
             bundle_id: com.tmsoft.mac.WhiteNoiseLite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 Mac App Store Cookbook CHANGELOG
 ================================
 
-v?.?.? (????-??-??)
--------------------
+Unreleased
+----------
+- Fix issue with bundled apps not getting accessibility rights
 
 v1.1.0 (2015-08-16)
 -------------------

--- a/Gemfile
+++ b/Gemfile
@@ -12,24 +12,21 @@ end
 
 group :test do
   gem 'rake'
-  gem 'cane'
-  gem 'countloc'
   gem 'rubocop'
   gem 'foodcritic'
-  gem 'rspec', '>= 3'
-  gem 'chefspec', '>= 4'
+  gem 'rspec'
+  gem 'chefspec'
   gem 'simplecov'
   gem 'simplecov-console'
   gem 'coveralls'
   gem 'fauxhai'
   gem 'test-kitchen'
   gem 'kitchen-localhost'
-  gem 'kitchen-vagrant', '>= 0.16.0'
+  gem 'kitchen-vagrant'
 end
 
 group :integration do
-  gem 'serverspec', '>= 2'
-  gem 'cucumber'
+  gem 'serverspec'
 end
 
 group :deploy do
@@ -38,6 +35,6 @@ end
 
 group :production do
   gem 'chef', '>= 12'
-  gem 'berkshelf', '>= 3'
+  gem 'berkshelf'
   gem 'AXElements', '~> 7.0'
 end

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ License & Authors
 =================
 - Author: Jonathan Hartman <j@p4nt5.com>
 
-Copyright 2015 Jonathan Hartman
+Copyright 2015-2016, Jonathan Hartman
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Rakefile
+++ b/Rakefile
@@ -1,24 +1,14 @@
 # Encoding: UTF-8
 
 require 'rubygems'
-require 'English'
 require 'bundler/setup'
 require 'rubocop/rake_task'
-require 'cane/rake_task'
 require 'rspec/core/rake_task'
 require 'foodcritic'
 require 'kitchen/rake_tasks'
 require 'stove/rake_task'
 
-Cane::RakeTask.new
-
 RuboCop::RakeTask.new
-
-desc 'Display LOC stats'
-task :loc do
-  puts "\n## LOC Stats"
-  Kernel.system 'countloc -r .'
-end
 
 FoodCritic::Rake::LintTask.new do |f|
   f.options = { fail_tags: %w(any) }
@@ -30,4 +20,4 @@ Kitchen::RakeTasks.new
 
 Stove::RakeTask.new
 
-task default: %w(cane rubocop loc foodcritic spec)
+task default: %w(rubocop foodcritic spec)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: mac-app-store
 # Attributes:: default
 #
-# Copyright 2015 Jonathan Hartman
+# Copyright 2015-2016, Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -58,7 +58,7 @@ module MacAppStoreCookbook
     #
     def wait_for_install(app_name, timeout)
       # Button might be 'Installed' or 'Open' depending on OS X version
-      fail(Exceptions::Timeout, "'#{app_name}' installation") unless wait_for(
+      raise(Exceptions::Timeout, "'#{app_name}' installation") unless wait_for(
         :button,
         app_page(app_name),
         description: /^(Installed,|Open,)/,
@@ -76,7 +76,7 @@ module MacAppStoreCookbook
     # @return [TrueClass, FalseClass]
     #
     def app_installed?(app_name)
-      app_page_button(app_name).description.match(/^Open,/) ? true : false
+      app_page_button(app_name).description =~ /^Open,/ ? true : false
     end
 
     #
@@ -89,7 +89,7 @@ module MacAppStoreCookbook
     #
     def latest_version(app_name)
       app_page(app_name).main_window.static_text(value: 'Version: ').parent
-        .static_text(value: /^[0-9]/).value
+                        .static_text(value: /^[0-9]/).value
     end
 
     #
@@ -121,7 +121,7 @@ module MacAppStoreCookbook
         unless wait_for(:button,
                         app_store.main_window,
                         description: /^(Install,|Download,|Installed,|Open,)/)
-          fail(Exceptions::Timeout, "'#{app_name}' app page")
+          raise(Exceptions::Timeout, "'#{app_name}' app page")
         end
       end
       app_store
@@ -133,7 +133,7 @@ module MacAppStoreCookbook
     # @raise [MacAppStoreCookbook::Exceptions::AppNotPurchased]
     #
     def fail_unless_purchased(app_name)
-      purchased?(app_name) || fail(Exceptions::AppNotPurchased, app_name)
+      purchased?(app_name) || raise(Exceptions::AppNotPurchased, app_name)
     end
 
     #
@@ -173,12 +173,12 @@ module MacAppStoreCookbook
     # @raise [MacAppStoreCookbook::Exceptions::UserNotSignedIn]
     #
     def purchased
-      signed_in? || fail(Exceptions::UserNotSignedIn)
+      signed_in? || raise(Exceptions::UserNotSignedIn)
       unless app_store.main_window.web_area.description == 'Purchased'
         select_menu_item(app_store, 'Store', 'Purchased')
       end
       unless wait_for(:table, app_store.main_window, description: 'Purchased')
-        fail(Exceptions::Timeout, 'Purchased list')
+        raise(Exceptions::Timeout, 'Purchased list')
       end
       app_store
     end
@@ -201,7 +201,7 @@ module MacAppStoreCookbook
     #
     def sign_in!(username, password)
       return if signed_in? && current_user? == username
-      fail(Exceptions::AppleIDInfoMissing) unless username && password
+      raise(Exceptions::AppleIDInfoMissing) unless username && password
       sign_out!
       sign_in_menu
       set(username_field, username)
@@ -216,7 +216,7 @@ module MacAppStoreCookbook
     # @raise [MacAppStoreCookbook::Exceptions::Timeout]
     #
     def wait_for_sign_in
-      fail(Exceptions::Timeout, 'sign in') unless wait_for(
+      raise(Exceptions::Timeout, 'sign in') unless wait_for(
         :menu_item,
         app_store.menu_bar_item(title: 'Store'),
         title: 'Sign Out'
@@ -275,7 +275,7 @@ module MacAppStoreCookbook
         unless wait_for(:button,
                         app_store.main_window,
                         title: 'Sign In')
-          fail(Exceptions::Timeout, 'Sign In window')
+          raise(Exceptions::Timeout, 'Sign In window')
         end
       end
       app_store
@@ -290,8 +290,8 @@ module MacAppStoreCookbook
     def current_user?
       return nil unless signed_in?
       app_store.menu_bar_item(title: 'Store')
-        .menu_item(title: /^View My Account /)
-        .title[/^View My Account \((.*)\)/, 1]
+               .menu_item(title: /^View My Account /)
+               .title[/^View My Account \((.*)\)/, 1]
     end
 
     #
@@ -326,11 +326,11 @@ module MacAppStoreCookbook
       # The page loading can be funky, especially on a slow machine. Some
       # elements don't even load in a consistent order, so try to wait until
       # everything we need to interact with is loaded.
-      wait_for(:standard_window, as) || fail(Exceptions::Timeout, 'App Store')
-      fail(Exceptions::Timeout, 'App Store') unless wait_for(:web_area,
-                                                             as.main_window)
+      wait_for(:standard_window, as) || raise(Exceptions::Timeout, 'App Store')
+      raise(Exceptions::Timeout, 'App Store') unless wait_for(:web_area,
+                                                              as.main_window)
       unless wait_for(:radio_button, as.main_window.toolbar, id: 'purchased')
-        fail(Exceptions::Timeout, 'App Store toolbar nav buttons')
+        raise(Exceptions::Timeout, 'App Store toolbar nav buttons')
       end
       as
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: mac-app-store
 # Library:: helpers
 #
-# Copyright 2015 Jonathan Hartman
+# Copyright 2015-2016, Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: mac-app-store
 # Library:: matchers
 #
-# Copyright 2015 Jonathan Hartman
+# Copyright 2015-2016, Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/provider_mac_app_store.rb
+++ b/libraries/provider_mac_app_store.rb
@@ -127,7 +127,7 @@ class Chef
         psm = privacy_services_manager "Grant Accessibility rights to #{app}" do
           service 'accessibility'
           applications [app]
-          admin true
+          admin true if app.start_with?('/')
         end
         psm.run_action(:add)
       end

--- a/libraries/provider_mac_app_store.rb
+++ b/libraries/provider_mac_app_store.rb
@@ -125,9 +125,9 @@ class Chef
         include_recipe_now 'privacy_services_manager'
         app = current_application_name
         psm = privacy_services_manager "Grant Accessibility rights to #{app}" do
+          admin true if app.start_with?('/')
           service 'accessibility'
           applications [app]
-          admin true if app.start_with?('/')
         end
         psm.run_action(:add)
       end

--- a/libraries/provider_mac_app_store.rb
+++ b/libraries/provider_mac_app_store.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: mac-app-store
 # Library:: provider_mac_app_store
 #
-# Copyright 2015 Jonathan Hartman
+# Copyright 2015-2016, Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/provider_mac_app_store.rb
+++ b/libraries/provider_mac_app_store.rb
@@ -33,7 +33,7 @@ class Chef
       include Chef::DSL::IncludeRecipe
       include MacAppStoreCookbook::Helpers
 
-      AXE_VERSION ||= '~> 7.0'
+      AXE_VERSION ||= '~> 7.0'.freeze
 
       use_inline_resources
 

--- a/libraries/provider_mac_app_store_app.rb
+++ b/libraries/provider_mac_app_store_app.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: mac-app-store
 # Library:: provider_mac_app_store_app
 #
-# Copyright 2015 Jonathan Hartman
+# Copyright 2015-2016, Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/resource_mac_app_store.rb
+++ b/libraries/resource_mac_app_store.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: mac-app-store
 # Library:: resource_mac_app_store
 #
-# Copyright 2015 Jonathan Hartman
+# Copyright 2015-2016, Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/resource_mac_app_store.rb
+++ b/libraries/resource_mac_app_store.rb
@@ -36,7 +36,7 @@ class Chef
       attribute :running,
                 kind_of: [NilClass, TrueClass, FalseClass],
                 default: nil
-      alias_method :running?, :running
+      alias running? running
 
       #
       # An optional Apple ID username

--- a/libraries/resource_mac_app_store_app.rb
+++ b/libraries/resource_mac_app_store_app.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: mac-app-store
 # Library:: resource_mac_app_store_app
 #
-# Copyright 2015 Jonathan Hartman
+# Copyright 2015-2016, Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/resource_mac_app_store_app.rb
+++ b/libraries/resource_mac_app_store_app.rb
@@ -36,7 +36,7 @@ class Chef
       attribute :installed,
                 kind_of: [NilClass, TrueClass, FalseClass],
                 default: nil
-      alias_method :installed?, :installed
+      alias installed? installed
 
       #
       # The name of the app to be installed (defaults to the resource name).

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,5 @@
 # Encoding: UTF-8
-#
-# rubocop:disable SingleSpaceBeforeFirstArg
+
 name             'mac-app-store'
 maintainer       'Jonathan Hartman'
 maintainer_email 'j@p4nt5.com'
@@ -14,4 +13,3 @@ depends          'now', '~> 0.3'
 depends          'privacy_services_manager', '~> 1.0'
 
 supports         'mac_os_x'
-# rubocop:enable SingleSpaceBeforeFirstArg

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: mac-app-store
 # Recipe:: default
 #
-# Copyright 2015 Jonathan Hartman
+# Copyright 2015-2016, Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 #
 
 unless node['platform'] == 'mac_os_x'
-  fail(Chef::Exceptions::UnsupportedPlatform, node['platform'])
+  raise(Chef::Exceptions::UnsupportedPlatform, node['platform'])
 end
 
 apps = (node['mac_app_store']['apps'] || []).map do |a|
@@ -28,7 +28,7 @@ apps = (node['mac_app_store']['apps'] || []).map do |a|
   elsif a.is_a?(String)
     { name: a, bundle_id: nil }
   else
-    fail(Chef::Exceptions::ValidationFailed, "Invalid app entry '#{a}'")
+    raise(Chef::Exceptions::ValidationFailed, "Invalid app entry '#{a}'")
   end
 end
 

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -442,7 +442,7 @@ describe MacAppStoreCookbook::Helpers do
 
       it_behaves_like 'user signed in'
 
-      it 'selects Purchased from the dropdown menu'do
+      it 'selects Purchased from the dropdown menu' do
         expect_any_instance_of(described_class).to receive(:select_menu_item)
           .with(app_store, 'Store', 'Purchased')
         test_obj.purchased

--- a/spec/libraries/provider_mac_app_store_app_spec.rb
+++ b/spec/libraries/provider_mac_app_store_app_spec.rb
@@ -9,12 +9,13 @@ describe Chef::Provider::MacAppStoreApp do
   %i(app_name timeout bundle_id).each { |a| let(a) { nil } }
   let(:timeout) { nil }
   let(:bundle_id) { nil }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
   let(:new_resource) do
-    r = Chef::Resource::MacAppStoreApp.new(name, nil)
+    r = Chef::Resource::MacAppStoreApp.new(name, run_context)
     %i(app_name timeout bundle_id).each { |a| r.send(a, send(a)) }
     r
   end
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_mac_app_store_spec.rb
+++ b/spec/libraries/provider_mac_app_store_spec.rb
@@ -10,14 +10,16 @@ describe Chef::Provider::MacAppStore do
   let(:system_wide) { double(focused_application: 'focused app') }
   let(:app_store_running?) { false }
   let(:sign_in!) { true }
+  let(:name) { 'default' }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
   let(:new_resource) do
-    r = Chef::Resource::MacAppStore.new(nil)
+    r = Chef::Resource::MacAppStore.new(name, run_context)
     %i(username password).each do |m|
       r.send(m, send(m))
     end
     r
   end
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe 'AXE_VERSION' do
     it 'pins AXE to 7 prerelease' do
@@ -254,9 +256,9 @@ describe Chef::Provider::MacAppStore do
         expect(p).to receive(:privacy_services_manager)
           .with("Grant Accessibility rights to #{current_application_name}")
           .and_yield
+        expect(p).to_not receive(:admin)
         expect(p).to receive(:service).with('accessibility')
         expect(p).to receive(:applications).with([current_application_name])
-        expect(p).to receive(:admin).with(true)
           .and_return(psm_resource)
         expect(psm_resource).to receive(:run_action).with(:add)
         p.send(:trust_app)
@@ -273,10 +275,10 @@ describe Chef::Provider::MacAppStore do
         expect(p).to receive(:privacy_services_manager)
           .with("Grant Accessibility rights to #{current_application_name}")
           .and_yield
+        expect(p).to receive(:admin).with(true)
         expect(p).to receive(:service).with('accessibility')
         expect(p).to receive(:applications).with([current_application_name])
           .and_return(psm_resource)
-        expect(p).to_not receive(:admin)
         expect(psm_resource).to receive(:run_action).with(:add)
         p.send(:trust_app)
       end

--- a/spec/libraries/resource_mac_app_store_app_spec.rb
+++ b/spec/libraries/resource_mac_app_store_app_spec.rb
@@ -6,8 +6,9 @@ require_relative '../../libraries/resource_mac_app_store_app'
 describe Chef::Resource::MacAppStoreApp do
   let(:name) { 'Some App' }
   %i(app_name timeout bundle_id).each { |a| let(a) { nil } }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
   let(:resource) do
-    r = described_class.new(name, nil)
+    r = described_class.new(name, run_context)
     %i(app_name timeout bundle_id).each { |a| r.send(a, send(a)) }
     r
   end

--- a/spec/libraries/resource_mac_app_store_spec.rb
+++ b/spec/libraries/resource_mac_app_store_spec.rb
@@ -5,8 +5,10 @@ require_relative '../../libraries/resource_mac_app_store'
 
 describe Chef::Resource::MacAppStore do
   %i(username password).each { |i| let(i) { nil } }
+  let(:name) { 'default' }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
   let(:resource) do
-    r = described_class.new(nil)
+    r = described_class.new(name, run_context)
     %i(username password).each do |a|
       r.send(a, send(a))
     end

--- a/test/integration/two-sample-apps/serverspec/localhost/package_spec.rb
+++ b/test/integration/two-sample-apps/serverspec/localhost/package_spec.rb
@@ -2,38 +2,40 @@
 
 require 'spec_helper'
 
-describe 'Microsoft Remote Desktop app' do
-  describe package('com.microsoft.rdc.mac') do
-    it 'is installed' do
-      expect(subject).to be_installed.by(:pkgutil)
+describe 'mac-app-store::two-sample-apps::package' do
+  describe 'Microsoft Remote Desktop app' do
+    describe package('com.microsoft.rdc.mac') do
+      it 'is installed' do
+        expect(subject).to be_installed.by(:pkgutil)
+      end
+    end
+  
+    describe file('/Applications/Microsoft Remote Desktop.app') do
+      it 'is present on the filesystem' do
+        expect(subject).to be_directory
+      end
     end
   end
-
-  describe file('/Applications/Microsoft Remote Desktop.app') do
-    it 'is present on the filesystem' do
-      expect(subject).to be_directory
+  
+  describe 'White Noise Lite app' do
+    describe package('com.tmsoft.mac.WhiteNoiseLite') do
+      it 'is installed' do
+        expect(subject).to be_installed.by(:pkgutil)
+      end
+    end
+  
+    describe file('/Applications/WhiteNoiseFree.app') do
+      it 'is present on the filesystem' do
+        expect(subject).to be_directory
+      end
     end
   end
-end
-
-describe 'White Noise Lite app' do
-  describe package('com.tmsoft.mac.WhiteNoiseLite') do
-    it 'is installed' do
-      expect(subject).to be_installed.by(:pkgutil)
-    end
-  end
-
-  describe file('/Applications/WhiteNoiseLite.app') do
-    it 'is present on the filesystem' do
-      expect(subject).to be_directory
-    end
-  end
-end
-
-describe 'Mac App Store' do
-  describe command('pgrep "App Store"') do
-    it 'exits 1 (App Store not running)' do
-      expect(subject.exit_status).to eq(1)
+  
+  describe 'Mac App Store' do
+    describe command('pgrep "App Store"') do
+      it 'exits 1 (App Store not running)' do
+        expect(subject.exit_status).to eq(1)
+      end
     end
   end
 end

--- a/test/integration/two-sample-apps/serverspec/localhost/package_spec.rb
+++ b/test/integration/two-sample-apps/serverspec/localhost/package_spec.rb
@@ -9,28 +9,28 @@ describe 'mac-app-store::two-sample-apps::package' do
         expect(subject).to be_installed.by(:pkgutil)
       end
     end
-  
+
     describe file('/Applications/Microsoft Remote Desktop.app') do
       it 'is present on the filesystem' do
         expect(subject).to be_directory
       end
     end
   end
-  
+
   describe 'White Noise Lite app' do
     describe package('com.tmsoft.mac.WhiteNoiseLite') do
       it 'is installed' do
         expect(subject).to be_installed.by(:pkgutil)
       end
     end
-  
+
     describe file('/Applications/WhiteNoiseFree.app') do
       it 'is present on the filesystem' do
         expect(subject).to be_directory
       end
     end
   end
-  
+
   describe 'Mac App Store' do
     describe command('pgrep "App Store"') do
       it 'exits 1 (App Store not running)' do


### PR DESCRIPTION
In the latest privacy_service_manager + OS X El Capitan, privileges are no longer granted if the admin option is passed in for bundled applications. It should only use it for bin paths.