### PR TITLE
Add an optional system_user attribute/property

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,4 +9,4 @@
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 114
+  Max: 115

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ If desired, a specific version of Mas can be installed rather than the latest:
 
     default['mac_app_store']['mas']['version'] = nil
 
+By default, Mas will always be run as the current system user. That can be
+overridden:
+
+    default['mac_app_store']['mas']['system_user'] = nil
+
 Resources
 =========
 
@@ -75,9 +80,10 @@ Syntax:
 
     mac_app_store_mas 'default' do
       source :direct
+      version: '1.2.3'
       username 'example@example.com'
       password 'abc123'
-      version: '1.2.3'
+      system_user 'vagrant'
       action %i(install sign_in)
     end
 
@@ -94,13 +100,14 @@ Actions:
 
 Properties:
 
-| Property | Default               | Description                                    |
-|----------|-----------------------|------------------------------------------------|
-| source   | `:direct`             | Install from GitHub (`:direct`) or `:homebrew` |
-| version  | `nil`                 | The version of Mas to install                  |
-| username | `nil`                 | An Apple ID username                           |
-| password | `nil`                 | An Apple ID password                           |
-| action   | `%i(install sign_in)` | Action(s) to perform                           |
+| Property    | Default               | Description                                    |
+|-------------|-----------------------|------------------------------------------------|
+| source      | `:direct`             | Install from GitHub (`:direct`) or `:homebrew` |
+| version     | `nil`                 | The version of Mas to install                  |
+| username    | `nil`                 | An Apple ID username                           |
+| password    | `nil`                 | An Apple ID password                           |
+| system_user | `Etc.getlogin`        | The user to execute Mas commands as            |
+| action      | `%i(install sign_in)` | Action(s) to perform                           |
 
 ***mac_app_store_app***
 
@@ -111,6 +118,7 @@ Syntax:
 
     mac_app_store_app 'Some App' do
       app_name 'Some App'
+      system_user 'vagrant'
       action :install
     end
 
@@ -123,10 +131,11 @@ Actions:
 
 Properties:
 
-| Property | Default       | Description                                |
-|----------|---------------|--------------------------------------------|
-| app_name | resource name | App name if it doesn't match resource name |
-| action   | `:install`    | Action(s) to perform                       |
+| Property    | Default        | Description                                |
+|-------------|----------------|--------------------------------------------|
+| app_name    | resource name  | App name if it doesn't match resource name |
+| system_user | `Etc.getlogin` | The user to execute Mas commands as        |
+| action      | `:install`     | Action(s) to perform                       |
 
 Contributing
 ============

--- a/README.md
+++ b/README.md
@@ -10,33 +10,24 @@ Mac App Store Cookbook
 [codeclimate]: https://codeclimate.com/github/RoboticCheese/mac-app-store-chef
 [coveralls]: https://coveralls.io/r/RoboticCheese/mac-app-store-chef
 
-A Chef cookbook for installation of Mac App Store apps.
+A Chef cookbook for installation of Mac App Store apps via the
+[Mas](https://github.com/argon/mas) CLI tool.
 
 Requirements
 ============
 
-Obviously, OS X is required. Some tempered expectations are as well--there is
-no documented public API for installing App Store apps, so this cookbook works
-by automating GUI window switches and button clicks.
-
-Nothing in this cookbook will attempt to purchase an app for you--it can only
-install ones that are already in your purchase history.
-
-As of v2.0, this cookbook requires Chef 12.5 or higher (or Chef 12.x and the
+Mas requires OS X 10.10+. As of v2.0, this cookbook requires Chef 12.5+ (or
+Chef 12.x and the
 [compat_resource](https://supermarket.chef.io/cookbooks/compat_resource)
 cookbook.
+
+A user must be logged into OS X for Mas to operate properly.
 
 Usage
 =====
 
 Apps can be installed by using the included custom resources in recipes of your
 own, or with the predefined recipe and set of attributes.
-
-Known Limitations
------------------
-
-* A user must be logged into OS X for Mas (the underlying utility we use to
-  manage installed apps) can function.
 
 Recipes
 =======
@@ -92,22 +83,23 @@ Syntax:
 
 Actions:
 
-| Action      | Description                        |
-|-------------|------------------------------------|
-| `:install`  | Default; install the Mas CLI       |
-| `:upgrade`  | Upgrade Mas, if available          |
-| `:remove`   | Uninstall Mas                      |
-| `:sign_in`  | Use Mas to sign into the App Store |
-| `:sign_out` | Sign out of the App Store          |
+| Action          | Description                                 |
+|-----------------|---------------------------------------------|
+| `:install`      | Default; install the Mas CLI                |
+| `:upgrade`      | Upgrade Mas, if available                   |
+| `:remove`       | Uninstall Mas                               |
+| `:sign_in`      | Use Mas to sign into the App Store          |
+| `:sign_out`     | Sign out of the App Store                   |
+| `:upgrade_apps` | Install any upgrades for apps on the system |
 
 Properties:
 
 | Property | Default               | Description                                    |
 |----------|-----------------------|------------------------------------------------|
 | source   | `:direct`             | Install from GitHub (`:direct`) or `:homebrew` |
+| version  | `nil`                 | The version of Mas to install                  |
 | username | `nil`                 | An Apple ID username                           |
 | password | `nil`                 | An Apple ID password                           |
-| version  | `nil`                 | The version of Mas to install                  |
 | action   | `%i(install sign_in)` | Action(s) to perform                           |
 
 ***mac_app_store_app***
@@ -127,6 +119,7 @@ Actions:
 | Action     | Description                     |
 |------------|---------------------------------|
 | `:install` | Default; installs the given app |
+| `:upgrade` | Upgrade or install the app      |
 
 Properties:
 
@@ -140,10 +133,11 @@ Contributing
 
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Add tests for the new feature; ensure they pass (`rake`)
+3. Add tests for the new feature; ensure they pass (`bundle exec rake`)
 4. Commit your changes (`git commit -am 'Add some feature'`)
 5. Push to the branch (`git push origin my-new-feature`)
 6. Create a new Pull Request
+7. Watch the pull request and ensure the build passes
 
 License & Authors
 =================

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,3 +25,4 @@ default['mac_app_store']['apps'] = {}
 
 default['mac_app_store']['mas']['source'] = nil
 default['mac_app_store']['mas']['version'] = nil
+default['mac_app_store']['mas']['system_user'] = nil

--- a/libraries/resource_mac_app_store_app.rb
+++ b/libraries/resource_mac_app_store_app.rb
@@ -37,6 +37,11 @@ class Chef
       #
       property :app_name, String, name_property: true
 
+      #
+      # The system user to execute Mas commands as.
+      #
+      property :system_user, String, default: Etc.getlogin, desired_state: false
+
       ######################################################################
       # Every property below this point is for tracking resource state and #
       # should *not* be overridden.                                        #
@@ -67,7 +72,7 @@ class Chef
           raise(Exceptions::InvalidAppName, new_resource.app_name) unless app_id
           execute "Install #{new_resource.app_name} with Mas" do
             command "mas install #{app_id}"
-            user Etc.getlogin
+            user new_resource.system_user
           end
         end
       end
@@ -81,7 +86,7 @@ class Chef
           raise(Exceptions::InvalidAppName, new_resource.app_name) unless app_id
           execute "Upgrade #{new_resource.app_name} with Mas" do
             command "mas install #{app_id}"
-            user Etc.getlogin
+            user new_resource.system_user
           end
         end
       end

--- a/libraries/resource_mac_app_store_mas.rb
+++ b/libraries/resource_mac_app_store_mas.rb
@@ -60,6 +60,11 @@ class Chef
       #
       property :password, String, desired_state: false
 
+      #
+      # The system user to execute Mas commands as,
+      #
+      property :system_user, String, default: Etc.getlogin, desired_state: false
+
       ######################################################################
       # Every property below this point is for tracking resource state and #
       # should *not* be overridden.                                        #
@@ -174,7 +179,7 @@ class Chef
           execute "Sign in to Mas as #{new_resource.username}" do
             command "mas signin #{new_resource.username}" \
                     " #{new_resource.password}"
-            user Etc.getlogin
+            user new_resource.system_user
             returns [0, 6]
             sensitive true
           end
@@ -190,7 +195,7 @@ class Chef
         converge_if_changed :username do
           execute 'Sign out of Mas' do
             command 'mas signout'
-            user Etc.getlogin
+            user new_resource.system_user
           end
         end
       end
@@ -204,7 +209,7 @@ class Chef
         converge_if_changed :upgradable_apps do
           execute 'Upgrade all installed apps' do
             command 'mas upgrade'
-            user Etc.getlogin
+            user new_resource.system_user
           end
         end
       end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,9 +31,17 @@ mac_app_store_mas 'default' do
   unless node['mac_app_store']['mas']['version'].nil?
     version node['mac_app_store']['mas']['version']
   end
+  unless node['mac_app_store']['mas']['system_user'].nil?
+    system_user node['mac_app_store']['mas']['system_user']
+  end
   action %i(install sign_in)
 end
 
 node['mac_app_store']['apps'].to_h.each do |k, v|
-  mac_app_store_app(k) if v == true
+  next unless v == true
+  mac_app_store_app k do
+    unless node['mac_app_store']['mas']['system_user'].nil?
+      system_user node['mac_app_store']['mas']['system_user']
+    end
+  end
 end

--- a/spec/resources/mac_app_store_app/mac_os_x/10_10_spec.rb
+++ b/spec/resources/mac_app_store_app/mac_os_x/10_10_spec.rb
@@ -2,16 +2,16 @@ require_relative '../../../spec_helper'
 require_relative '../../../../libraries/helpers_app'
 
 describe 'resource_mac_app_store_app::mac_os_x::10_10' do
-  %i(name app_name action).each do |p|
+  %i(name app_name system_user action).each do |p|
     let(p) { nil }
   end
   %i(installed? upgradable? app_id_for?).each { |i| let(i) { nil } }
-  let(:user) { 'vagrant' }
+  let(:getlogin) { 'vagrant' }
   let(:runner) do
     ChefSpec::SoloRunner.new(
       step_into: 'mac_app_store_app', platform: 'mac_os_x', version: '10.10'
     ) do |node|
-      %i(name app_name action).each do |p|
+      %i(name app_name system_user action).each do |p|
         unless send(p).nil?
           node.set['resource_mac_app_store_app_test'][p] = send(p)
         end
@@ -31,38 +31,48 @@ describe 'resource_mac_app_store_app::mac_os_x::10_10' do
     }.each do |k, v|
       allow(MacAppStore::Helpers::App).to receive(k).and_return(v)
     end
-    allow(Etc).to receive(:getlogin).and_return(user)
+    allow(Etc).to receive(:getlogin).and_return(getlogin)
   end
 
   context 'the default action (:install)' do
     let(:action) { nil }
+    let(:name) { 'Some App' }
+    let(:app_id_for?) { 'abc123' }
 
-    context 'no extra properties' do
-      let(:name) { 'Some App' }
+    context 'app not already installed' do
+      let(:installed?) { false }
+      let(:app_id_for?) { 'abc123' }
 
-      context 'app not already installed' do
-        let(:installed?) { false }
-        let(:app_id_for?) { 'abc123' }
+      context 'no extra properties' do
         cached(:chef_run) { converge }
 
         it 'installs the app' do
           expect(chef_run).to run_execute("Install #{name} with Mas")
-            .with(command: "mas install #{app_id_for?}", user: user)
+            .with(command: "mas install #{app_id_for?}", user: getlogin)
         end
       end
 
-      context 'app already installed' do
-        let(:installed?) { true }
-        let(:app_id_for?) { 'abc123' }
+      context 'an overridden app_name property' do
+        let(:app_name) { 'Other App' }
         cached(:chef_run) { converge }
 
-        it 'does not install the app' do
-          expect(chef_run).to_not run_execute("Install #{name} with Mas")
+        it 'installs the app with the correct name' do
+          expect(chef_run).to run_execute("Install #{app_name} with Mas")
+            .with(command: "mas install #{app_id_for?}", user: getlogin)
         end
       end
 
-      context 'app not installed and non-existent' do
-        let(:installed?) { false }
+      context 'an overridden system_user property' do
+        let(:system_user) { 'testme' }
+        cached(:chef_run) { converge }
+
+        it 'installs the app with the correct system user' do
+          expect(chef_run).to run_execute("Install #{name} with Mas")
+            .with(command: "mas install #{app_id_for?}", user: system_user)
+        end
+      end
+
+      context 'app non-existent' do
         let(:app_id_for?) { nil }
         cached(:chef_run) { converge }
 
@@ -73,88 +83,55 @@ describe 'resource_mac_app_store_app::mac_os_x::10_10' do
       end
     end
 
-    context 'an overridden app_name property' do
-      let(:name) { 'Some App' }
-      let(:app_name) { 'Other App' }
+    context 'app already installed' do
+      let(:installed?) { true }
+      cached(:chef_run) { converge }
 
-      context 'app not already installed' do
-        let(:installed?) { false }
-        let(:app_id_for?) { 'abc123' }
-        cached(:chef_run) { converge }
-
-        it 'installs the app' do
-          expect(chef_run).to run_execute("Install #{app_name} with Mas")
-            .with(command: "mas install #{app_id_for?}", user: user)
-        end
-      end
-
-      context 'app already installed' do
-        let(:installed?) { true }
-        let(:app_id_for?) { 'abc123' }
-        cached(:chef_run) { converge }
-
-        it 'does not install the app' do
-          expect(chef_run).to_not run_execute("Install #{app_name} with Mas")
-        end
-      end
-
-      context 'app not installed and non-existent' do
-        let(:installed?) { false }
-        let(:app_id_for?) { nil }
-        cached(:chef_run) { converge }
-
-        it 'raises an error' do
-          expected = Chef::Resource::MacAppStoreApp::Exceptions::InvalidAppName
-          expect { chef_run }.to raise_error(expected)
-        end
+      it 'does not install the app' do
+        expect(chef_run).to_not run_execute("Install #{name} with Mas")
       end
     end
   end
 
   context 'the :upgrade action' do
     let(:action) { :upgrade }
+    let(:name) { 'Some App' }
+    let(:app_id_for?) { 'abc123' }
 
-    context 'no extra properties' do
-      let(:name) { 'Some App' }
+    context 'app not already installed' do
+      let(:installed?) { false }
+      let(:upgradable?) { nil }
 
-      context 'app not already installed' do
-        let(:installed?) { false }
-        let(:upgradable?) { nil }
-        let(:app_id_for?) { 'abc123' }
+      context 'no extra properties' do
         cached(:chef_run) { converge }
 
         it 'installs the app' do
           expect(chef_run).to run_execute("Upgrade #{name} with Mas")
-            .with(command: "mas install #{app_id_for?}", user: user)
+            .with(command: "mas install #{app_id_for?}", user: getlogin)
         end
       end
 
-      context 'app installed and upgradable' do
-        let(:installed?) { true }
-        let(:upgradable?) { true }
-        let(:app_id_for?) { 'abc123' }
+      context 'an overridden app_name property' do
+        let(:app_name) { 'Other App' }
         cached(:chef_run) { converge }
 
-        it 'upgrades the app' do
+        it 'upgrades the app with the correct name' do
+          expect(chef_run).to run_execute("Upgrade #{app_name} with Mas")
+            .with(command: "mas install #{app_id_for?}", user: getlogin)
+        end
+      end
+
+      context 'an overridden system_user property' do
+        let(:system_user) { 'testme' }
+        cached(:chef_run) { converge }
+
+        it 'upgrades the app with the correct system user' do
           expect(chef_run).to run_execute("Upgrade #{name} with Mas")
-            .with(command: "mas install #{app_id_for?}", user: user)
+            .with(command: "mas install #{app_id_for?}", user: system_user)
         end
       end
 
-      context 'app installed and not upgradable' do
-        let(:installed?) { true }
-        let(:upgradable?) { false }
-        let(:app_id_for?) { 'abc123' }
-        cached(:chef_run) { converge }
-
-        it 'does not upgrade the app' do
-          expect(chef_run).to_not run_execute("Upgrade #{name} with Mas")
-        end
-      end
-
-      context 'app not installed and non-existent' do
-        let(:installed?) { false }
-        let(:upgradable?) { nil }
+      context 'app non-existent' do
         let(:app_id_for?) { nil }
         cached(:chef_run) { converge }
 
@@ -165,54 +142,48 @@ describe 'resource_mac_app_store_app::mac_os_x::10_10' do
       end
     end
 
-    context 'an overridden app_name property' do
-      let(:name) { 'Some App' }
-      let(:app_name) { 'Other App' }
+    context 'app installed' do
+      let(:installed?) { true }
 
-      context 'app not already installed' do
-        let(:installed?) { false }
-        let(:upgradable?) { nil }
-        let(:app_id_for?) { 'abc123' }
-        cached(:chef_run) { converge }
-
-        it 'installs the app' do
-          expect(chef_run).to run_execute("Upgrade #{app_name} with Mas")
-            .with(command: "mas install #{app_id_for?}", user: user)
-        end
-      end
-
-      context 'app installed and upgradable' do
-        let(:installed?) { true }
+      context 'app upgradable' do
         let(:upgradable?) { true }
-        let(:app_id_for?) { 'abc123' }
-        cached(:chef_run) { converge }
 
-        it 'upgrades the app' do
-          expect(chef_run).to run_execute("Upgrade #{app_name} with Mas")
-            .with(command: "mas install #{app_id_for?}", user: user)
+        context 'no extra properties' do
+          cached(:chef_run) { converge }
+
+          it 'upgrades the app' do
+            expect(chef_run).to run_execute("Upgrade #{name} with Mas")
+              .with(command: "mas install #{app_id_for?}", user: getlogin)
+          end
+        end
+
+        context 'an overridden app_name property' do
+          let(:app_name) { 'Other App' }
+          cached(:chef_run) { converge }
+
+          it 'upgrades the app with the correct name' do
+            expect(chef_run).to run_execute("Upgrade #{app_name} with Mas")
+              .with(command: "mas install #{app_id_for?}", user: getlogin)
+          end
+        end
+
+        context 'an overridden system_user property' do
+          let(:system_user) { 'testme' }
+          cached(:chef_run) { converge }
+
+          it 'upgrades the app with the correct system user' do
+            expect(chef_run).to run_execute("Upgrade #{name} with Mas")
+              .with(command: "mas install #{app_id_for?}", user: system_user)
+          end
         end
       end
 
-      context 'app installed and not upgradable' do
-        let(:installed?) { true }
+      context 'app not upgradable' do
         let(:upgradable?) { false }
-        let(:app_id_for?) { 'abc123' }
         cached(:chef_run) { converge }
 
         it 'does not upgrade the app' do
-          expect(chef_run).to_not run_execute("Upgrade #{app_name} with Mas")
-        end
-      end
-
-      context 'app not installed and non-existent' do
-        let(:installed?) { false }
-        let(:upgradable?) { nil }
-        let(:app_id_for?) { nil }
-        cached(:chef_run) { converge }
-
-        it 'raises an error' do
-          expected = Chef::Resource::MacAppStoreApp::Exceptions::InvalidAppName
-          expect { chef_run }.to raise_error(expected)
+          expect(chef_run).to_not run_execute("Upgrade #{name} with Mas")
         end
       end
     end

--- a/spec/support/cookbooks/resource_mac_app_store_app_test/recipes/default.rb
+++ b/spec/support/cookbooks/resource_mac_app_store_app_test/recipes/default.rb
@@ -4,5 +4,6 @@ attrs = node['resource_mac_app_store_app_test']
 
 mac_app_store_app attrs['name'] do
   app_name attrs['app_name'] unless attrs['app_name'].nil?
+  system_user attrs['system_user'] unless attrs['system_user'].nil?
   action attrs['action'] unless attrs['action'].nil?
 end

--- a/spec/support/cookbooks/resource_mac_app_store_mas_test/recipes/default.rb
+++ b/spec/support/cookbooks/resource_mac_app_store_mas_test/recipes/default.rb
@@ -7,5 +7,6 @@ mac_app_store_mas attrs['name'] do
   version attrs['version'] unless attrs['version'].nil?
   username attrs['username'] unless attrs['username'].nil?
   password attrs['password'] unless attrs['password'].nil?
+  system_user attrs['system_user'] unless attrs['system_user'].nil?
   action attrs['action'] unless attrs['action'].nil?
 end


### PR DESCRIPTION
The chef-client service on OS X runs as the root user, so this should help with that hopefully.