### PR TITLE
Add the option of using reattach-to-user-namespace

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,4 +9,4 @@
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 118
+  Max: 138

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Mac App Store Cookbook CHANGELOG
 
 Unreleased
 ----------
+- Add the option of using reattach-to-user-namespace
 
 v2.0.3 (2016-06-02)
 -------------------

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ overridden:
 
     default['mac_app_store']['mas']['system_user'] = nil
 
+In certain circumstances-e.g. Chef running as root-it may be necessary to run
+Mas via the `reattach-to-user-namespace` utility:
+
+    default['mac_app_store']['mas']['use_rtun'] = nil
+
 Resources
 =========
 
@@ -84,6 +89,7 @@ Syntax:
       username 'example@example.com'
       password 'abc123'
       system_user 'vagrant'
+      use_rtun false
       action %i(install sign_in)
     end
 
@@ -107,6 +113,7 @@ Properties:
 | username    | `nil`                 | An Apple ID username                           |
 | password    | `nil`                 | An Apple ID password                           |
 | system_user | `Etc.getlogin`        | The user to execute Mas commands as            |
+| use_rtun    | `false`               | Use RtUN when shelling out to Mas              |
 | action      | `%i(install sign_in)` | Action(s) to perform                           |
 
 ***mac_app_store_app***
@@ -119,6 +126,7 @@ Syntax:
     mac_app_store_app 'Some App' do
       app_name 'Some App'
       system_user 'vagrant'
+      use_rtun false
       action :install
     end
 
@@ -135,6 +143,7 @@ Properties:
 |-------------|----------------|--------------------------------------------|
 | app_name    | resource name  | App name if it doesn't match resource name |
 | system_user | `Etc.getlogin` | The user to execute Mas commands as        |
+| use_rtun    | `false`        | Use RtUN when shelling out to Mas          |
 | action      | `:install`     | Action(s) to perform                       |
 
 Contributing

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,3 +26,4 @@ default['mac_app_store']['apps'] = {}
 default['mac_app_store']['mas']['source'] = nil
 default['mac_app_store']['mas']['version'] = nil
 default['mac_app_store']['mas']['system_user'] = nil
+default['mac_app_store']['mas']['use_rtun'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,5 +12,6 @@ source_url 'https://github.com/roboticcheese/mac-app-store-chef'
 issues_url 'https://github.com/roboticcheese/mac-app-store-chef/issues'
 
 depends 'homebrew', '~> 2.1'
+depends 'reattach-to-user-namespace', '~> 0.1'
 
 supports 'mac_os_x'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,6 +34,9 @@ mac_app_store_mas 'default' do
   unless node['mac_app_store']['mas']['system_user'].nil?
     system_user node['mac_app_store']['mas']['system_user']
   end
+  unless node['mac_app_store']['mas']['use_rtun'].nil?
+    use_rtun node['mac_app_store']['mas']['use_rtun']
+  end
   action %i(install sign_in)
 end
 
@@ -42,6 +45,9 @@ node['mac_app_store']['apps'].to_h.each do |k, v|
   mac_app_store_app k do
     unless node['mac_app_store']['mas']['system_user'].nil?
       system_user node['mac_app_store']['mas']['system_user']
+    end
+    unless node['mac_app_store']['mas']['use_rtun'].nil?
+      use_rtun node['mac_app_store']['mas']['use_rtun']
     end
   end
 end

--- a/spec/support/cookbooks/resource_mac_app_store_app_test/recipes/default.rb
+++ b/spec/support/cookbooks/resource_mac_app_store_app_test/recipes/default.rb
@@ -5,5 +5,6 @@ attrs = node['resource_mac_app_store_app_test']
 mac_app_store_app attrs['name'] do
   app_name attrs['app_name'] unless attrs['app_name'].nil?
   system_user attrs['system_user'] unless attrs['system_user'].nil?
+  use_rtun attrs['use_rtun'] unless attrs['use_rtun'].nil?
   action attrs['action'] unless attrs['action'].nil?
 end

--- a/spec/support/cookbooks/resource_mac_app_store_mas_test/recipes/default.rb
+++ b/spec/support/cookbooks/resource_mac_app_store_mas_test/recipes/default.rb
@@ -8,5 +8,6 @@ mac_app_store_mas attrs['name'] do
   username attrs['username'] unless attrs['username'].nil?
   password attrs['password'] unless attrs['password'].nil?
   system_user attrs['system_user'] unless attrs['system_user'].nil?
+  use_rtun attrs['use_rtun'] unless attrs['use_rtun'].nil?
   action attrs['action'] unless attrs['action'].nil?
 end


### PR DESCRIPTION
When Chef runs as a scheduled service in OS X, it runs as root in a way
that shelling out, even as a specific user, results in bad responses
from Mas. The reattach-to-user-namespace utility can help with this, but
let's leave it disabled by default.

```
$ mas account
j@p4nt5.com

$ sudo mas account
Not signed in

$ sudo su -
$ mas account
Not signed in

$ sudo -u jhartman mas account
Not signed in

$ sudo -u jhartman reattach-to-user-namespace mas account
j@p4nt5.com
```