### PR TITLE
Removes dependency on the homebrew cookbook

### DIFF
--- a/libraries/resource_mac_app_store_mas.rb
+++ b/libraries/resource_mac_app_store_mas.rb
@@ -123,7 +123,6 @@ class Chef
               command "unzip -d /usr/local/bin/ -o #{path}"
             end
           when :homebrew
-            include_recipe 'homebrew'
             homebrew_package 'mas'
           end
         end
@@ -153,7 +152,6 @@ class Chef
               command "unzip -d /usr/local/bin/ -o #{path}"
             end
           when :homebrew
-            include_recipe 'homebrew'
             homebrew_package('mas') { action :upgrade }
           end
         end
@@ -171,7 +169,6 @@ class Chef
           when :direct
             file('/usr/local/bin/mas') { action :delete }
           when :homebrew
-            include_recipe 'homebrew'
             homebrew_package('mas') { action :remove }
           end
         end

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,6 @@ version '2.1.1'
 source_url 'https://github.com/roboticcheese/mac-app-store-chef'
 issues_url 'https://github.com/roboticcheese/mac-app-store-chef/issues'
 
-depends 'homebrew', '~> 2.1'
 depends 'reattach-to-user-namespace', '~> 0.1'
 
 supports 'mac_os_x'

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,3 +14,5 @@ issues_url 'https://github.com/roboticcheese/mac-app-store-chef/issues'
 depends 'reattach-to-user-namespace', '~> 0.1'
 
 supports 'mac_os_x'
+
+chef_version '~> 12'

--- a/spec/resources/mac_app_store_mas/mac_os_x/10_10_spec.rb
+++ b/spec/resources/mac_app_store_mas/mac_os_x/10_10_spec.rb
@@ -106,10 +106,6 @@ describe 'resource_mac_app_store_mas::mac_os_x::10_10' do
           stub_command('which git').and_return('git')
         end
 
-        it 'includes the homebrew default recipe' do
-          expect(chef_run).to include_recipe('homebrew')
-        end
-
         it 'installs Mas via Homebrew' do
           expect(chef_run).to install_homebrew_package('mas')
         end
@@ -120,10 +116,6 @@ describe 'resource_mac_app_store_mas::mac_os_x::10_10' do
         let(:installed_version?) { '1.1.0' }
         let(:installed_by?) { :direct }
         cached(:chef_run) { converge }
-
-        it 'does not include the homebrew default recipe' do
-          expect(chef_run).to_not include_recipe('homebrew')
-        end
 
         it 'does not install Mas via Homebrew' do
           expect(chef_run).to_not install_homebrew_package('mas')
@@ -226,10 +218,6 @@ describe 'resource_mac_app_store_mas::mac_os_x::10_10' do
           stub_command('which git').and_return('git')
         end
 
-        it 'includes the homebrew default recipe' do
-          expect(chef_run).to include_recipe('homebrew')
-        end
-
         it 'upgrades Mas via Homebrew' do
           expect(chef_run).to upgrade_homebrew_package('mas')
         end
@@ -240,10 +228,6 @@ describe 'resource_mac_app_store_mas::mac_os_x::10_10' do
         let(:installed_version?) { '1.5.0' }
         let(:installed_by?) { :direct }
         cached(:chef_run) { converge }
-
-        it 'does not include the homebrew default recipe' do
-          expect(chef_run).to_not include_recipe('homebrew')
-        end
 
         it 'does not upgrade Mas via Homebrew' do
           expect(chef_run).to_not upgrade_homebrew_package('mas')
@@ -258,10 +242,6 @@ describe 'resource_mac_app_store_mas::mac_os_x::10_10' do
 
         before(:each) do
           stub_command('which git').and_return('git')
-        end
-
-        it 'includes the homebrew default recipe' do
-          expect(chef_run).to include_recipe('homebrew')
         end
 
         it 'upgrades Mas via Homebrew' do
@@ -289,10 +269,6 @@ describe 'resource_mac_app_store_mas::mac_os_x::10_10' do
 
       before(:each) do
         stub_command('which git').and_return('git')
-      end
-
-      it 'includes the homebrew default recipe' do
-        expect(chef_run).to include_recipe('homebrew')
       end
 
       it 'removes Mas via Homebrew' do


### PR DESCRIPTION
v3 of the homebrew cookbook was released recently which no longer has the `homebrew_package` resource. That resource has been included in Chef since v12.0.

This also sets the `chef_version` to `~> 12` in the metadata.