### PR TITLE
Make Homebrew the default Mas installation method

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,5 +19,3 @@ suites:
         apps:
           Microsoft Remote Desktop: true
           White Noise Free: true
-        mas:
-          version: 1.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 - Remove all system_user attributes and properties
 - Respect a version property in mac_app_store_mas::install
 - Raise an error if trying to use Mas before it's installed
+- Make Homebrew the default Mas installation method
 
 v2.1.0 (2016-06-08)
 -------------------

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ and value is true to install it or false to not. For example:
 
     default['mac_app_store']['apps']['Growl'] = true
 
-Mas can be installed via GitHub download (`:direct`, the default) or from
-`:homebrew`.
+Mas can be installed via Homebrew (`:homebrew`, the default) or GitHub
+download (`:direct`).
 
     default['mac_app_store']['mas']['source'] = nil
 
@@ -102,7 +102,7 @@ Properties:
 
 | Property    | Default               | Description                                    |
 |-------------|-----------------------|------------------------------------------------|
-| source      | `:direct`             | Install from GitHub (`:direct`) or `:homebrew` |
+| source      | `:homebrew`           | Install from `:homebrew` or GitHub (`:direct`) |
 | version     | `nil`                 | The version of Mas to install                  |
 | username    | `nil`                 | An Apple ID username                           |
 | password    | `nil`                 | An Apple ID password                           |

--- a/spec/resources/mac_app_store_mas.rb
+++ b/spec/resources/mac_app_store_mas.rb
@@ -49,6 +49,7 @@ shared_context 'resources::mac_app_store_mas' do
   end
 
   before(:each) do
+    stub_command('which git').and_return('/usr/bin/git')
   end
 
   shared_context 'the :install action' do
@@ -85,14 +86,11 @@ shared_context 'resources::mac_app_store_mas' do
   end
 
   shared_context 'an overridden source property' do
-    let(:source) { :homebrew }
-
-    before do
-      stub_command('which git').and_return('/usr/bin/git')
-    end
+    let(:source) { :direct }
   end
 
-  shared_context 'an overridden version property' do
+  shared_context 'an overridden source and version property' do
+    let(:source) { :direct }
     let(:version) { '0.1.0' }
   end
 

--- a/spec/resources/mac_app_store_mas/mac_os_x.rb
+++ b/spec/resources/mac_app_store_mas/mac_os_x.rb
@@ -20,6 +20,34 @@ shared_context 'resources::mac_app_store_mas::mac_os_x' do
         context 'not already installed' do
           include_context description
 
+          it 'includes the homebrew default recipe' do
+            expect(chef_run).to include_recipe('homebrew')
+          end
+
+          it 'installs Mas via Homebrew' do
+            expect(chef_run).to install_homebrew_package('mas')
+          end
+        end
+
+        context 'already installed' do
+          include_context description
+
+          it 'includes the homebrew default recipe' do
+            expect(chef_run).to include_recipe('homebrew')
+          end
+
+          it 'installs Mas via Homebrew' do
+            expect(chef_run).to install_homebrew_package('mas')
+          end
+        end
+      end
+
+      context 'an overridden source property' do
+        include_context description
+
+        context 'not already installed' do
+          include_context description
+
           it 'downloads mas-cli.zip from GitHub' do
             expect(chef_run).to create_remote_file(
               "#{Chef::Config[:file_cache_path]}/mas-cli.zip"
@@ -50,35 +78,7 @@ shared_context 'resources::mac_app_store_mas::mac_os_x' do
         end
       end
 
-      context 'an overridden source property' do
-        include_context description
-
-        context 'not already installed' do
-          include_context description
-
-          it 'includes the homebrew default recipe' do
-            expect(chef_run).to include_recipe('homebrew')
-          end
-
-          it 'installs Mas via Homebrew' do
-            expect(chef_run).to install_homebrew_package('mas')
-          end
-        end
-
-        context 'already installed' do
-          include_context description
-
-          it 'includes the homebrew default recipe' do
-            expect(chef_run).to include_recipe('homebrew')
-          end
-
-          it 'installs Mas via Homebrew' do
-            expect(chef_run).to install_homebrew_package('mas')
-          end
-        end
-      end
-
-      context 'an overridden version property' do
+      context 'an overridden source and version property' do
         include_context description
 
         context 'not already installed' do
@@ -125,6 +125,38 @@ shared_context 'resources::mac_app_store_mas::mac_os_x' do
       context 'all default properties' do
         include_context description
 
+        shared_examples_for 'any installed state' do
+          it 'includes the homebrew default recipe' do
+            expect(chef_run).to include_recipe('homebrew')
+          end
+
+          it 'upgrades Mas via Homebrew' do
+            expect(chef_run).to upgrade_homebrew_package('mas')
+          end
+        end
+
+        context 'not already installed' do
+          include_context description
+
+          it_behaves_like 'any installed state'
+        end
+
+        context 'already installed' do
+          include_context description
+
+          it_behaves_like 'any installed state'
+        end
+
+        context 'installed and upgradable' do
+          include_context description
+
+          it_behaves_like 'any installed state'
+        end
+      end
+
+      context 'an overridden source property' do
+        include_context description
+
         context 'not already installed' do
           include_context description
 
@@ -175,38 +207,6 @@ shared_context 'resources::mac_app_store_mas::mac_os_x' do
           end
         end
       end
-
-      context 'an overridden source property' do
-        include_context description
-
-        shared_examples_for 'any installed state' do
-          it 'includes the homebrew default recipe' do
-            expect(chef_run).to include_recipe('homebrew')
-          end
-
-          it 'upgrades Mas via Homebrew' do
-            expect(chef_run).to upgrade_homebrew_package('mas')
-          end
-        end
-
-        context 'not already installed' do
-          include_context description
-
-          it_behaves_like 'any installed state'
-        end
-
-        context 'already installed' do
-          include_context description
-
-          it_behaves_like 'any installed state'
-        end
-
-        context 'installed and upgradable' do
-          include_context description
-
-          it_behaves_like 'any installed state'
-        end
-      end
     end
 
     context 'the :remove action' do
@@ -218,20 +218,20 @@ shared_context 'resources::mac_app_store_mas::mac_os_x' do
         context 'all default properties' do
           include_context description
 
-          it 'deletes the mas file' do
-            expect(chef_run).to delete_file('/usr/local/bin/mas')
-          end
-        end
-
-        context 'an overridden source property' do
-          include_context description
-
           it 'includes the homebrew default recipe' do
             expect(chef_run).to include_recipe('homebrew')
           end
 
           it 'removes Mas via Homebrew' do
             expect(chef_run).to remove_homebrew_package('mas')
+          end
+        end
+
+        context 'an overridden source property' do
+          include_context description
+
+          it 'deletes the mas file' do
+            expect(chef_run).to delete_file('/usr/local/bin/mas')
           end
         end
       end
@@ -242,20 +242,20 @@ shared_context 'resources::mac_app_store_mas::mac_os_x' do
         context 'all default properties' do
           include_context description
 
-          it 'does not delete the mas file' do
-            expect(chef_run).to_not delete_file('/usr/local/bin/mas')
-          end
-        end
-
-        context 'an overridden source property' do
-          include_context description
-
           it 'does not include the homebrew default recipe' do
             expect(chef_run).to_not include_recipe('homebrew')
           end
 
           it 'does not remove Mas via Homebrew' do
             expect(chef_run).to_not remove_homebrew_package('mas')
+          end
+        end
+
+        context 'an overridden source property' do
+          include_context description
+
+          it 'does not delete the mas file' do
+            expect(chef_run).to_not delete_file('/usr/local/bin/mas')
           end
         end
       end


### PR DESCRIPTION
Homebrew is now explicitly stated as the prefered installation
method for Mas, so let's adhere to that recommendation while also
making reattach-to-user-namespace and mac-app-store have the same
defaults.