### PR TITLE
Allows v4.x of the homebrew cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ chef_version '>= 12.1'
 source_url 'https://github.com/roboticcheese/mac-app-store-chef'
 issues_url 'https://github.com/roboticcheese/mac-app-store-chef/issues'
 
-depends 'homebrew', '< 4.0'
+depends 'homebrew', '< 5.0'
 depends 'reattach-to-user-namespace', '~> 0.2'
 
 supports 'mac_os_x'


### PR DESCRIPTION
v4.x does not include any incompatibilities with v3.x for installing brew packages.