### PR TITLE
Removes dependency on the homebrew cookbook and sets chef_version to ~> 12

### DIFF
--- a/libraries/resource_mac_app_store_mas.rb
+++ b/libraries/resource_mac_app_store_mas.rb
@@ -90,7 +90,6 @@ class Chef
       action :install do
         case new_resource.source
         when :homebrew
-          include_recipe 'homebrew'
           homebrew_package 'mas'
         when :direct
           return if current_resource && \
@@ -117,7 +116,6 @@ class Chef
       action :upgrade do
         case new_resource.source
         when :homebrew
-          include_recipe 'homebrew'
           homebrew_package('mas') { action :upgrade }
         when :direct
           ver = new_resource.version || \
@@ -144,7 +142,6 @@ class Chef
 
         case new_resource.source
         when :homebrew
-          include_recipe 'homebrew'
           homebrew_package('mas') { action :remove }
         when :direct
           file('/usr/local/bin/mas') { action :delete }

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,3 +16,5 @@ issues_url 'https://github.com/roboticcheese/mac-app-store-chef/issues'
 depends 'reattach-to-user-namespace', '~> 0.2'
 
 supports 'mac_os_x'
+
+chef_version '~> 12'

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,6 @@ chef_version '>= 12.1'
 source_url 'https://github.com/roboticcheese/mac-app-store-chef'
 issues_url 'https://github.com/roboticcheese/mac-app-store-chef/issues'
 
-depends 'homebrew', '< 5.0'
 depends 'reattach-to-user-namespace', '~> 0.2'
 
 supports 'mac_os_x'

--- a/spec/resources/mac_app_store_mas/mac_os_x.rb
+++ b/spec/resources/mac_app_store_mas/mac_os_x.rb
@@ -20,10 +20,6 @@ shared_context 'resources::mac_app_store_mas::mac_os_x' do
         context 'not already installed' do
           include_context description
 
-          it 'includes the homebrew default recipe' do
-            expect(chef_run).to include_recipe('homebrew')
-          end
-
           it 'installs Mas via Homebrew' do
             expect(chef_run).to install_homebrew_package('mas')
           end
@@ -31,10 +27,6 @@ shared_context 'resources::mac_app_store_mas::mac_os_x' do
 
         context 'already installed' do
           include_context description
-
-          it 'includes the homebrew default recipe' do
-            expect(chef_run).to include_recipe('homebrew')
-          end
 
           it 'installs Mas via Homebrew' do
             expect(chef_run).to install_homebrew_package('mas')
@@ -126,10 +118,6 @@ shared_context 'resources::mac_app_store_mas::mac_os_x' do
         include_context description
 
         shared_examples_for 'any installed state' do
-          it 'includes the homebrew default recipe' do
-            expect(chef_run).to include_recipe('homebrew')
-          end
-
           it 'upgrades Mas via Homebrew' do
             expect(chef_run).to upgrade_homebrew_package('mas')
           end
@@ -218,10 +206,6 @@ shared_context 'resources::mac_app_store_mas::mac_os_x' do
         context 'all default properties' do
           include_context description
 
-          it 'includes the homebrew default recipe' do
-            expect(chef_run).to include_recipe('homebrew')
-          end
-
           it 'removes Mas via Homebrew' do
             expect(chef_run).to remove_homebrew_package('mas')
           end
@@ -241,10 +225,6 @@ shared_context 'resources::mac_app_store_mas::mac_os_x' do
 
         context 'all default properties' do
           include_context description
-
-          it 'does not include the homebrew default recipe' do
-            expect(chef_run).to_not include_recipe('homebrew')
-          end
 
           it 'does not remove Mas via Homebrew' do
             expect(chef_run).to_not remove_homebrew_package('mas')


### PR DESCRIPTION
The `homebrew_package` resource has been included in Chef since v12.0.

Chef 12 has already is [EOL](https://docs.chef.io/platforms.html#versions-and-status) so I think it's okay to require at least that.