### PR TITLE
Allows v5.x of the homebrew cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ chef_version '>= 12.1'
 source_url 'https://github.com/roboticcheese/mac-app-store-chef'
 issues_url 'https://github.com/roboticcheese/mac-app-store-chef/issues'
 
-depends 'homebrew', '< 5.0'
+depends 'homebrew', '< 6.0'
 depends 'reattach-to-user-namespace', '~> 0.2'
 
 supports 'mac_os_x'


### PR DESCRIPTION
In case you rather keep on depending on the homebrew cookbook this can be used instead of https://github.com/RoboticCheese/mac-app-store-chef/pull/51.