### PR TITLE
Fix search now that version numbers are returned by search

### DIFF
--- a/libraries/helpers_app.rb
+++ b/libraries/helpers_app.rb
@@ -75,7 +75,7 @@ module MacAppStore
         def app_id_for?(name)
           search = shell_out("mas search '#{name}'", user: user).stdout
           app_line = search.lines.find do |l|
-            l.rstrip.split(' ')[1..-1].join(' ') == name
+            l.rstrip.split(' ')[1..-2].join(' ') == name
           end
           app_line && app_line.split(' ')[0]
         end


### PR DESCRIPTION
`mas` now returns version numbers with search result. For example:
```
➜  mac-app-store-chef git:(search-fix) mas search Xcode
   497799835  Xcode                                                                (10.1)
  1183412116  Swiftify for Xcode                                                   (4.6.1)
  1163893338  App School for Xcode and  iOS 10 Development Free                    (1.0)
  1179007212  Code School for Xcode Free -Learn How to Make Apps                   (1.1.3)
  1083165894  Course for Xcode 7 Lite                                              (1.0)
  ...
```

This change fixes the `mac_app_store_app` resource. I wasn't able to get the tests to run due to lots of gem version conflicts, so I haven't updated them yet. Happy to do so later, but it's going to require some rework of said tests.